### PR TITLE
Fix a graphical glitch that happen in the following scenario :

### DIFF
--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -678,8 +678,12 @@ export function D3Blueprint(container) {
             .attr('opacity', 1)
             .attr('stroke', 'red')
             .attr('d', function(d) {
-                let targetNode = nodeForEntity(d.target);
-                let sourceNode = nodeForEntity(d.source);
+                try {
+                    var targetNode = nodeForEntity(d.target);
+                    var sourceNode = nodeForEntity(d.source);
+                } catch (error) {
+                    return '';
+                }
                 let sourceY = sourceNode.y + (d.source.isMemberSpec() ? _configHolder.nodes.memberspec.circle.cy : 0);
                 let targetY = targetNode.y + (d.target.isMemberSpec() ? _configHolder.nodes.memberspec.circle.cy : 0);
                 let dx = targetNode.x - sourceNode.x;


### PR DESCRIPTION
-create a blueprint
-add two entities
-in the configuration of one of them (A) reference the other (B)
-delete B => redraw fail, and leave both entity but only one (vertical) line between "New Appliance" and the entities