### PR TITLE
As a UI user, I cannot deploy a blueprint if the appliance is not ready

### DIFF
--- a/ui-modules/blueprint-composer/app/components/not-ready-appliance/not-ready-appliance.directive.js
+++ b/ui-modules/blueprint-composer/app/components/not-ready-appliance/not-ready-appliance.directive.js
@@ -56,8 +56,13 @@ function link($scope) {
     }
 
     let closePopover = (event) => {
-        $scope.warningIconClicked = false;
-        $scope.$apply();
+        if($scope.warningIconClicked) {
+            $scope.warningIconClicked = false;
+            var phase = $scope.$root.$$phase;
+            if(phase != '$apply' && phase != '$digest') {
+                $scope.$apply();
+            }
+        }
     }
 
     $scope.$on('scroll-svg', closePopover);


### PR DESCRIPTION
Created an array to keep track of appliance that are blueprint compliant.
When the composed blueprint is no longer compliant, an event is broadcast to the root scope. When it is compliant again, another event is broadcast.
Fixed an issue with the use of $scope.$apply() that was outputing error in the console when a digest was already in progress.